### PR TITLE
Adds TestFlight LAN server mode, CLI flags, and iOS app icon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,6 @@ meridian-ios/.build/
 meridian-ios/.swiftpm/
 **/.build/
 
-# iOS app icon (generated from assets/app-icon.png by build script)
-meridian-ios/Assets.xcassets/AppIcon.appiconset/AppIcon.png
-
 # Design source backups
 * copy.ai
 

--- a/meridian-ios/APIService.swift
+++ b/meridian-ios/APIService.swift
@@ -39,16 +39,20 @@ struct CheckIn {
 
 final class APIService {
     static let shared = APIService()
-    private let baseURL: String
+    private var baseURL: String { Config.resolvedApiBaseURL }
     private let session: URLSession
 
-    init(baseURL: String = Config.apiBaseURL) {
-        self.baseURL = baseURL
+    private init() {
         let config = URLSessionConfiguration.default
         config.httpCookieStorage = HTTPCookieStorage.shared
         config.httpShouldSetCookies = true
         config.httpCookieAcceptPolicy = .always
         self.session = URLSession(configuration: config)
+    }
+
+    /// Call after changing API base URL so session cookies do not target the old host.
+    func clearHttpCookies() {
+        HTTPCookieStorage.shared.cookies?.forEach { HTTPCookieStorage.shared.deleteCookie($0) }
     }
 
     private func url(_ path: String) -> URL? {

--- a/meridian-ios/Assets.xcassets/AppIcon.appiconset/AppIcon.png
+++ b/meridian-ios/Assets.xcassets/AppIcon.appiconset/AppIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c74d25b45d1daf06ae04d5f7b0d2fd258d1ccb2bc39d542444377f84ea9ed3d
+size 26453

--- a/meridian-ios/Config.swift
+++ b/meridian-ios/Config.swift
@@ -1,16 +1,66 @@
 /**
  * Meridian iOS – API configuration.
- * Change API_BASE_URL for local vs Railway/production.
- * All iOS/Swift code is isolated in meridian-ios/; no repo coupling.
+ *
+ * Precedence for `resolvedApiBaseURL`:
+ *  1. UserDefaults (Developer tab / login) — non-empty saved override
+ *  2. Info.plist `MERIDIAN_API_URL` only (Xcode → target → Build Settings → `MERIDIAN_API_URL` / `INFOPLIST_KEY_MERIDIAN_API_URL`)
  */
 import Foundation
 
 enum Config {
-    /// API base URL (no trailing slash). Local: http://127.0.0.1:8000 ; Railway: your deployed URL.
-    static var apiBaseURL: String {
-        (Bundle.main.object(forInfoDictionaryKey: "MERIDIAN_API_URL") as? String)?
+    private static let savedApiBaseURLKey = "meridian_api_base_url"
+
+    static let apiBaseURLDidChangeNotification = Notification.Name("meridianApiBaseURLDidChange")
+
+    static func normalizedBaseURL(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        while s.hasSuffix("/") {
+            s.removeLast()
+        }
+        return s
+    }
+
+    /// True if the string is a usable http(s) API base URL (avoids empty / malformed URLs).
+    static func isValidHttpBaseURL(_ urlString: String) -> Bool {
+        guard !urlString.isEmpty,
+              let u = URL(string: urlString),
+              let scheme = u.scheme,
+              scheme == "http" || scheme == "https",
+              u.host != nil, !(u.host?.isEmpty ?? true) else {
+            return false
+        }
+        return true
+    }
+
+    /// Value baked into the app at build time (Info.plist `MERIDIAN_API_URL` only).
+    static var launchBundledApiBaseURL: String {
+        let fromPlist = (Bundle.main.object(forInfoDictionaryKey: "MERIDIAN_API_URL") as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "/$", with: "", options: .regularExpression)
-            ?? "http://127.0.0.1:8000"
+            .replacingOccurrences(of: "/$", with: "", options: .regularExpression) ?? ""
+        return normalizedBaseURL(fromPlist)
+    }
+
+    /// Effective API base URL (no trailing slash).
+    static var resolvedApiBaseURL: String {
+        if let s = UserDefaults.standard.string(forKey: savedApiBaseURLKey) {
+            let t = normalizedBaseURL(s)
+            if !t.isEmpty { return t }
+        }
+        return launchBundledApiBaseURL
+    }
+
+    static func saveApiBaseURL(_ raw: String) {
+        let t = normalizedBaseURL(raw)
+        if t.isEmpty {
+            UserDefaults.standard.removeObject(forKey: savedApiBaseURLKey)
+        } else {
+            UserDefaults.standard.set(t, forKey: savedApiBaseURLKey)
+        }
+    }
+
+    static var apiBaseURL: String { resolvedApiBaseURL }
+
+    static func persistedApiBaseURLFieldText() -> String {
+        UserDefaults.standard.string(forKey: savedApiBaseURLKey) ?? ""
     }
 }

--- a/meridian-ios/DeveloperViewController.swift
+++ b/meridian-ios/DeveloperViewController.swift
@@ -1,0 +1,92 @@
+/**
+ * Meridian iOS – Temporary: change API base URL without rebuilding (same Wi-Fi / LAN server).
+ */
+import UIKit
+
+final class DeveloperViewController: UIViewController {
+    private let urlField = UITextField()
+    private let effectiveLabel = UILabel()
+    private let bundledLabel = UILabel()
+    private let statusLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "Developer"
+
+        urlField.placeholder = "API base URL (e.g. http://192.168.1.10:8000)"
+        urlField.borderStyle = .roundedRect
+        urlField.autocapitalizationType = .none
+        urlField.autocorrectionType = .no
+        urlField.keyboardType = .URL
+        urlField.textContentType = .URL
+
+        effectiveLabel.numberOfLines = 0
+        effectiveLabel.font = .preferredFont(forTextStyle: .subheadline)
+        effectiveLabel.textColor = .secondaryLabel
+
+        bundledLabel.numberOfLines = 0
+        bundledLabel.font = .preferredFont(forTextStyle: .caption1)
+        bundledLabel.textColor = .tertiaryLabel
+
+        statusLabel.numberOfLines = 0
+        statusLabel.textAlignment = .center
+        statusLabel.font = .preferredFont(forTextStyle: .footnote)
+
+        let saveButton = UIButton(type: .system)
+        saveButton.setTitle("Save & return to login", for: .normal)
+        saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
+
+        let clearButton = UIButton(type: .system)
+        clearButton.setTitle("Use build default only", for: .normal)
+        clearButton.addTarget(self, action: #selector(clearTapped), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [
+            urlField, effectiveLabel, bundledLabel, saveButton, clearButton, statusLabel
+        ])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            urlField.heightAnchor.constraint(equalToConstant: 44),
+            saveButton.heightAnchor.constraint(equalToConstant: 44),
+            clearButton.heightAnchor.constraint(equalToConstant: 44),
+            stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16)
+        ])
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        urlField.text = Config.resolvedApiBaseURL
+        refreshLabels()
+    }
+
+    private func refreshLabels() {
+        effectiveLabel.text = "Effective now: \(Config.resolvedApiBaseURL)"
+        bundledLabel.text = "Build default (Info.plist MERIDIAN_API_URL): \(Config.launchBundledApiBaseURL)"
+    }
+
+    @objc private func saveTapped() {
+        Config.saveApiBaseURL(urlField.text ?? "")
+        APIService.shared.clearHttpCookies()
+        refreshLabels()
+        statusLabel.text = "Saved. Returning to login…"
+        statusLabel.textColor = .secondaryLabel
+        NotificationCenter.default.post(name: Config.apiBaseURLDidChangeNotification, object: nil)
+    }
+
+    @objc private func clearTapped() {
+        Config.saveApiBaseURL("")
+        urlField.text = Config.resolvedApiBaseURL
+        APIService.shared.clearHttpCookies()
+        refreshLabels()
+        statusLabel.text = "Cleared override. Using build default."
+        statusLabel.textColor = .secondaryLabel
+        NotificationCenter.default.post(name: Config.apiBaseURLDidChangeNotification, object: nil)
+    }
+}

--- a/meridian-ios/LoginViewController.swift
+++ b/meridian-ios/LoginViewController.swift
@@ -4,6 +4,8 @@
 import UIKit
 
 final class LoginViewController: UIViewController {
+    private let serverUrlField = UITextField()
+    private let serverDefaultHintLabel = UILabel()
     private let userIdField = UITextField()
     private let familyCircleField = UITextField()
     private let loginButton = UIButton(type: .system)
@@ -16,6 +18,20 @@ final class LoginViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         title = "Meridian"
+
+        serverUrlField.placeholder = "Server URL (e.g. http://192.168.1.10:8000)"
+        serverUrlField.borderStyle = .roundedRect
+        serverUrlField.autocapitalizationType = .none
+        serverUrlField.autocorrectionType = .no
+        serverUrlField.keyboardType = .URL
+        serverUrlField.textContentType = .URL
+        let persisted = Config.persistedApiBaseURLFieldText()
+        serverUrlField.text = persisted.isEmpty ? nil : persisted
+
+        serverDefaultHintLabel.numberOfLines = 0
+        serverDefaultHintLabel.font = .preferredFont(forTextStyle: .caption1)
+        serverDefaultHintLabel.textColor = .secondaryLabel
+        serverDefaultHintLabel.text = "Default API: \(Config.launchBundledApiBaseURL)"
 
         userIdField.placeholder = "User ID (e.g. fm_001)"
         userIdField.borderStyle = .roundedRect
@@ -42,7 +58,7 @@ final class LoginViewController: UIViewController {
         spinner.hidesWhenStopped = true
 
         let stack = UIStackView(arrangedSubviews: [
-            userIdField, familyCircleField, loginButton, spinner, statusLabel
+            serverUrlField, serverDefaultHintLabel, userIdField, familyCircleField, loginButton, spinner, statusLabel
         ])
         stack.axis = .vertical
         stack.spacing = 12
@@ -51,6 +67,7 @@ final class LoginViewController: UIViewController {
 
         view.addSubview(stack)
         NSLayoutConstraint.activate([
+            serverUrlField.heightAnchor.constraint(equalToConstant: 44),
             userIdField.heightAnchor.constraint(equalToConstant: 44),
             familyCircleField.heightAnchor.constraint(equalToConstant: 44),
             loginButton.heightAnchor.constraint(equalToConstant: 44),
@@ -66,6 +83,15 @@ final class LoginViewController: UIViewController {
         let fid = familyCircleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !uid.isEmpty, !fid.isEmpty else {
             statusLabel.text = "Enter user ID and family circle ID"
+            statusLabel.textColor = .systemRed
+            return
+        }
+
+        let trimmedServer = serverUrlField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        Config.saveApiBaseURL(trimmedServer)
+        let base = Config.resolvedApiBaseURL
+        guard Config.isValidHttpBaseURL(base) else {
+            statusLabel.text = "Missing or invalid server URL. Set MERIDIAN_API_URL in Xcode (build) or enter an override above."
             statusLabel.textColor = .systemRed
             return
         }

--- a/meridian-ios/MainTabViewController.swift
+++ b/meridian-ios/MainTabViewController.swift
@@ -9,7 +9,8 @@ final class MainTabViewController: UITabBarController {
         viewControllers = [
             wrapped(AlertViewController(), title: "Alert", image: UIImage(systemName: "exclamationmark.triangle.fill")),
             wrapped(CheckInViewController(), title: "Check-In", image: UIImage(systemName: "location.fill")),
-            wrapped(ChatListViewController(), title: "Chat", image: UIImage(systemName: "message.fill"))
+            wrapped(ChatListViewController(), title: "Chat", image: UIImage(systemName: "message.fill")),
+            wrapped(DeveloperViewController(), title: "Developer", image: UIImage(systemName: "hammer.fill"))
         ]
     }
 

--- a/meridian-ios/MeridianFamily-Info.plist
+++ b/meridian-ios/MeridianFamily-Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MERIDIAN_API_URL</key>
+	<string>http://192.168.14.15:8000</string>
+</dict>
+</plist>

--- a/meridian-ios/MeridianFamily.xcodeproj/project.pbxproj
+++ b/meridian-ios/MeridianFamily.xcodeproj/project.pbxproj
@@ -15,10 +15,11 @@
 		801D06B2994A2C2B3668DC29 /* MainTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303FA187AB1D71C58A9C40CE /* MainTabViewController.swift */; };
 		8BCB12B1E4FACBB31534CA0F /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6F681986AB20651305D17B /* RootViewController.swift */; };
 		9B8863312E390F61E07D5EAB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C91B6ED00D7322EFF6E640 /* Assets.xcassets */; };
-		C3F0A5E4D3F6927180C5D6E7F /* LocationRefreshHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E3C2B1D4705968A3B4C5D /* LocationRefreshHandler.swift */; };
-		D4A1B6F5E4A7038291D6E7F80 /* PendingLocationRequestPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E9F4D3C2E5816079B4C5D6E /* PendingLocationRequestPrompt.swift */; };
 		B89C9318EE4388A2A2D06F1C /* CheckInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C82ACDDE6C4F47B8C6D466 /* CheckInViewController.swift */; };
 		BBBDE559D982994A39983A47 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D843BEA5D3D3871F086B2E /* LoginViewController.swift */; };
+		C3F0A5E4D3F6927180C5D6E7F /* LocationRefreshHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E3C2B1D4705968A3B4C5D /* LocationRefreshHandler.swift */; };
+		D4A1B6F5E4A7038291D6E7F80 /* PendingLocationRequestPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E9F4D3C2E5816079B4C5D6E /* PendingLocationRequestPrompt.swift */; };
+		E7F6D5C4B3A291817161514F /* DeveloperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E6F5D4C3B2A190817161514E /* DeveloperViewController.swift */; };
 		EF281502C91FD4197E29E2D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37789B7F3A74C9BD1EBB34FE /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -32,12 +33,14 @@
 		5D7DD1A44A58B2397915FFCD /* Meridian.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Meridian.xcodeproj; sourceTree = "<group>"; };
 		640206CF5CBA2A4150B96A6E /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		9E6F681986AB20651305D17B /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
-		B1F6D2321F89EFB06A10B925 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
-		B6C82ACDDE6C4F47B8C6D466 /* CheckInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInViewController.swift; sourceTree = "<group>"; };
 		A1F8E3C2B1D4705968A3B4C5D /* LocationRefreshHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRefreshHandler.swift; sourceTree = "<group>"; };
+		B1F6D2321F89EFB06A10B925 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		B2E9F4D3C2E5816079B4C5D6E /* PendingLocationRequestPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingLocationRequestPrompt.swift; sourceTree = "<group>"; };
+		B6C82ACDDE6C4F47B8C6D466 /* CheckInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInViewController.swift; sourceTree = "<group>"; };
 		C41A18C072EB83280908C1C6 /* MeridianFamily.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MeridianFamily.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D70B8E00B319FD55ED226C47 /* ChatWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWebViewController.swift; sourceTree = "<group>"; };
+		D7E6F5D4C3B2A190817161514E /* DeveloperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperViewController.swift; sourceTree = "<group>"; };
+		F0A1B2C3D4E5F60718293A4B5C /* MeridianFamily-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MeridianFamily-Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -52,6 +55,8 @@
 				D70B8E00B319FD55ED226C47 /* ChatWebViewController.swift */,
 				B6C82ACDDE6C4F47B8C6D466 /* CheckInViewController.swift */,
 				516554ACFC2387E32EE80CF6 /* Config.swift */,
+				D7E6F5D4C3B2A190817161514E /* DeveloperViewController.swift */,
+				F0A1B2C3D4E5F60718293A4B5C /* MeridianFamily-Info.plist */,
 				00D843BEA5D3D3871F086B2E /* LoginViewController.swift */,
 				A1F8E3C2B1D4705968A3B4C5D /* LocationRefreshHandler.swift */,
 				303FA187AB1D71C58A9C40CE /* MainTabViewController.swift */,
@@ -163,6 +168,7 @@
 				05A769A3D9789D3800BD5ED5 /* ChatWebViewController.swift in Sources */,
 				B89C9318EE4388A2A2D06F1C /* CheckInViewController.swift in Sources */,
 				31E41F9A5077F75E4A63F823 /* Config.swift in Sources */,
+				E7F6D5C4B3A291817161514F /* DeveloperViewController.swift in Sources */,
 				BBBDE559D982994A39983A47 /* LoginViewController.swift in Sources */,
 				C3F0A5E4D3F6927180C5D6E7F /* LocationRefreshHandler.swift in Sources */,
 				801D06B2994A2C2B3668DC29 /* MainTabViewController.swift in Sources */,
@@ -178,12 +184,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = V2KY58YNP3;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MeridianFamily-Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MeridianFamily;
+				INFOPLIST_KEY_MERIDIAN_API_URL = "http://192.168.14.15:8000";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Meridian connects to your family server on the same Wi-Fi network.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "When you tap Check In, Meridian records your current location and shares it with your family circle so they can see where you are. Location is only used at check-in time, not continuously.";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -193,10 +205,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.meridian.MeridianFamily;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -325,12 +337,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = V2KY58YNP3;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MeridianFamily-Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MeridianFamily;
+				INFOPLIST_KEY_MERIDIAN_API_URL = "http://192.168.14.15:8000";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Meridian connects to your family server on the same Wi-Fi network.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "When you tap Check In, Meridian records your current location and shares it with your family circle so they can see where you are. Location is only used at check-in time, not continuously.";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -341,10 +359,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.meridian.MeridianFamily;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};

--- a/meridian-ios/RootViewController.swift
+++ b/meridian-ios/RootViewController.swift
@@ -6,7 +6,21 @@ import UIKit
 final class RootViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(apiBaseURLDidChange),
+            name: Config.apiBaseURLDidChangeNotification,
+            object: nil
+        )
         checkSessionAndShowAppropriateScreen()
+    }
+
+    @objc private func apiBaseURLDidChange() {
+        showLogin()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/meridian-ios/project.yml
+++ b/meridian-ios/project.yml
@@ -8,10 +8,6 @@ targets:
     type: application
     platform: iOS
     supportedDestinations: [iOS]
-    preBuildScripts:
-      - script: |
-          cp "$SRCROOT/../assets/app-icon.png" "$SRCROOT/Assets.xcassets/AppIcon.appiconset/AppIcon.png"
-        name: Copy shared app icon
     sources:
       - path: .
         excludes:


### PR DESCRIPTION
- Merge latest main into 121-testflight-where-is-everyone.
- Add python main.py --testflight: bind API on 0.0.0.0, fixed port, print LAN URL so phones on the same Wi‑Fi can reach the Mac (vs localhost-only).
- Treat --local and --testflight as mutually exclusive; keep env/argv handling at startup.
- Point the MeridianFamily app icon at the asset-catalog AppIcon (1024×1024).